### PR TITLE
Interpret escape sequences in KEY=VALUE pairs as literal strings.

### DIFF
--- a/bin/dconf-dump
+++ b/bin/dconf-dump
@@ -16,7 +16,7 @@ dump_dconf_dir() {
         echo "$1" | sed 's,/\(.*\)/,[\1],'
         echo "$ENTRIES" | grep '[^/]$' | sort | while IFS= read -r ITEM
         do
-            echo "$ITEM=$(dconf read "$1$ITEM")"
+            printf "%s=%s\n" "$ITEM" "$(dconf read "$1$ITEM")"
         done
     fi
 


### PR DESCRIPTION
Hey,

I was looking to sort the output of dconf and this was the 1st hit on Google to my query. Found an issue on my 1st test run.

Example:
We want:

```
[org/mate/pluma]
history-search-for=['aaaa\nbbbb\tcccc\ndddd\neee']
```

We got:

```
[org/mate/pluma]
history-search-for=['aaaa
bbbb    cccc
dddd
eee']
```

Other than that it does the job perfectly.
